### PR TITLE
Add emoticons to keyboard text, add share/unshare for items

### DIFF
--- a/action_handlers/create_bill_handler.py
+++ b/action_handlers/create_bill_handler.py
@@ -241,7 +241,7 @@ class DisplayNewBillKB(Action):
     @staticmethod
     def get_new_bill_keyboard(bill_id):
         modify_items_btn = InlineKeyboardButton(
-            text="Add/Edit Items",
+            text="📝 Add/Edit Items",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_MODIFY_ITEMS_KB,
@@ -249,7 +249,7 @@ class DisplayNewBillKB(Action):
             )
         )
         modify_taxes_btn = InlineKeyboardButton(
-            text="Add/Edit Taxes",
+            text="💸 Add/Edit Taxes",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_MODIFY_TAXES_KB,
@@ -257,7 +257,7 @@ class DisplayNewBillKB(Action):
             )
         )
         done_btn = InlineKeyboardButton(
-            text="Done",
+            text="👍 Done",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_CREATE_BILL_DONE,
@@ -288,7 +288,7 @@ class DisplayModifyItemsKB(Action):
     @staticmethod
     def get_modify_items_keyboard(bill_id):
         add_item_btn = InlineKeyboardButton(
-            text="Add item(s)",
+            text="➕ Add item(s)",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_ADD_ITEMS,
@@ -296,7 +296,7 @@ class DisplayModifyItemsKB(Action):
             )
         )
         edit_item_btn = InlineKeyboardButton(
-            text="Edit item",
+            text="🔃 Edit item",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_EDIT_ITEM_KB,
@@ -304,7 +304,7 @@ class DisplayModifyItemsKB(Action):
             )
         )
         del_item_btn = InlineKeyboardButton(
-            text="Delete item",
+            text="➖ Delete item",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_DELETE_ITEM_KB,
@@ -312,7 +312,7 @@ class DisplayModifyItemsKB(Action):
             )
         )
         back_btn = InlineKeyboardButton(
-            text="Back",
+            text="🔙 Back",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_NEW_BILL_KB,
@@ -344,7 +344,7 @@ class DisplayModifyTaxesKB(Action):
     @staticmethod
     def get_modify_taxes_keyboard(bill_id):
         add_tax_btn = InlineKeyboardButton(
-            text="Add tax",
+            text="➕ Add tax",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_ADD_TAX,
@@ -352,7 +352,7 @@ class DisplayModifyTaxesKB(Action):
             )
         )
         edit_tax_btn = InlineKeyboardButton(
-            text="Edit tax",
+            text="🔃 Edit tax",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_EDIT_TAX_KB,
@@ -360,7 +360,7 @@ class DisplayModifyTaxesKB(Action):
             )
         )
         del_tax_btn = InlineKeyboardButton(
-            text="Delete tax",
+            text="➖ Delete tax",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_DELETE_TAX_KB,
@@ -368,7 +368,7 @@ class DisplayModifyTaxesKB(Action):
             )
         )
         back_btn = InlineKeyboardButton(
-            text="Back",
+            text="🔙 Back",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_NEW_BILL_KB,

--- a/action_handlers/manage_bill_handler.py
+++ b/action_handlers/manage_bill_handler.py
@@ -167,11 +167,11 @@ class DisplayManageBillKB(Action):
     def get_manage_bill_keyboard(bill_id, trans):
         bill_name, __, __, __ = trans.get_bill_gen_info(bill_id)
         share_btn = InlineKeyboardButton(
-            text="Share Bill",
+            text="📮 Share Bill",
             switch_inline_query=bill_name
         )
         refresh_btn = InlineKeyboardButton(
-            text="Refresh Bill",
+            text="🔄 Refresh Bill",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_REFRESH_BILL,
@@ -179,7 +179,7 @@ class DisplayManageBillKB(Action):
             )
         )
         share_items = InlineKeyboardButton(
-            text="Add yourself to Item(s)",
+            text="🙋 Add yourself to Item(s)",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_SHARE_ITEMS_KB,
@@ -187,7 +187,7 @@ class DisplayManageBillKB(Action):
             )
         )
         calc_bill_btn = InlineKeyboardButton(
-            text="Calculate Split",
+            text="⚖ Calculate Split",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_CALCULATE_SPLIT,
@@ -222,17 +222,19 @@ class DisplayShareItemsKB(Action):
         __, owner_id, __, closed_at = trans.get_bill_gen_info(bill_id)
         if owner_id == user_id:
             return DisplayShareItemsKB.get_share_items_admin_keyboard(
-                bill_id, trans
+                bill_id, trans, user_id
             )
         else:
-            return DisplayShareItemsKB.get_share_items_keyboard(bill_id, trans)
+            return DisplayShareItemsKB.get_share_items_keyboard(
+            bill_id, trans, user_id
+            )
 
     @staticmethod
-    def get_share_items_keyboard(bill_id, trans):
+    def get_share_items_keyboard(bill_id, trans, user_id):
         keyboard = []
         items = trans.get_bill_items(bill_id)
         refresh_btn = InlineKeyboardButton(
-            text='Refresh',
+            text='🔄 Refresh',
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_REFRESH_BILL,
@@ -241,8 +243,12 @@ class DisplayShareItemsKB(Action):
         )
         keyboard.append([refresh_btn])
         for item_id, item_name, __ in items:
+            if trans.has_bill_share(bill_id, item_id, user_id):
+                text="👋 Unshare " + item_name
+            else:
+                text='☝️ Share ' + item_name
             item_btn = InlineKeyboardButton(
-                text=item_name,
+                text=text,
                 callback_data=utils.get_action_callback_data(
                     MODULE_ACTION_TYPE,
                     ACTION_SHARE_BILL_ITEM,
@@ -251,8 +257,16 @@ class DisplayShareItemsKB(Action):
                 )
             )
             keyboard.append([item_btn])
+
+
+        text="🙅 Unshare all items"
+        for item_id, item_name, __ in items:
+            if not trans.has_bill_share(bill_id, item_id, user_id):
+                text='🙌 Share all items'
+                break
+
         share_all_btn = InlineKeyboardButton(
-            text='Share all items',
+            text=text,
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_SHARE_ALL_ITEMS,
@@ -264,12 +278,16 @@ class DisplayShareItemsKB(Action):
         return InlineKeyboardMarkup(keyboard)
 
     @staticmethod
-    def get_share_items_admin_keyboard(bill_id, trans):
+    def get_share_items_admin_keyboard(bill_id, trans, user_id):
         keyboard = []
         items = trans.get_bill_items(bill_id)
         for item_id, item_name, __ in items:
+            if trans.has_bill_share(bill_id, item_id, user_id):
+                text="👋 Unshare " + item_name
+            else:
+                text='☝️ Share ' + item_name
             item_btn = InlineKeyboardButton(
-                text=item_name,
+                text=text,
                 callback_data=utils.get_action_callback_data(
                     MODULE_ACTION_TYPE,
                     ACTION_SHARE_BILL_ITEM,
@@ -278,8 +296,15 @@ class DisplayShareItemsKB(Action):
                 )
             )
             keyboard.append([item_btn])
+
+        text="🙅 Unshare all items"
+        for item_id, item_name, __ in items:
+            if not trans.has_bill_share(bill_id, item_id, user_id):
+                text='🙌 Share all items'
+                break
+
         share_all_btn = InlineKeyboardButton(
-            text='Share all items',
+            text=text,
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_SHARE_ALL_ITEMS,
@@ -288,7 +313,7 @@ class DisplayShareItemsKB(Action):
         )
         keyboard.append([share_all_btn])
         back_btn = InlineKeyboardButton(
-            text='Back',
+            text='🔙 Back',
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_MANAGE_BILL_KB,
@@ -329,7 +354,7 @@ class DisplayPayItemsKB(Action):
         keyboard = []
         keyboard.extend(DisplayPayItemsKB.get_payment_buttons(bill_id, trans))
         refresh_btn = InlineKeyboardButton(
-            text='Refresh',
+            text='🔄 Refresh',
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_REFRESH_BILL,
@@ -344,7 +369,7 @@ class DisplayPayItemsKB(Action):
         keyboard = []
         keyboard.extend(DisplayPayItemsKB.get_payment_buttons(bill_id, trans))
         back_btn = InlineKeyboardButton(
-            text='Back',
+            text='🔙 Back',
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_MANAGE_BILL_KB,
@@ -364,7 +389,7 @@ class DisplayPayItemsKB(Action):
         for debt in debts:
             credtr = debt['creditor']
             pay_btn = InlineKeyboardButton(
-                text='Pay ' + utils.format_name(
+                text='💸 Pay ' + utils.format_name(
                     credtr[3], credtr[1], credtr[2]
                 ),
                 callback_data=utils.get_action_callback_data(
@@ -712,7 +737,7 @@ class DisplayConfirmPaymentsKB(Action):
         kb = []
         for payment in pending:
             btn = InlineKeyboardButton(
-                text='{}  {}{:.4f}'.format(
+                text='✅ {}  {}{:.4f}'.format(
                     utils.format_name(payment[4], payment[2], payment[3]),
                     const.EMOJI_MONEY_BAG,
                     payment[1],
@@ -727,7 +752,7 @@ class DisplayConfirmPaymentsKB(Action):
             kb.append([btn])
 
         back_btn = InlineKeyboardButton(
-            text="Back",
+            text="🔙 Back",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_REFRESH_BILL,
@@ -809,11 +834,11 @@ class SendDebtsBillAdmin(Action):
     def get_debts_bill_msg(bill_id, trans):
         bill_name, __, __, __ = trans.get_bill_gen_info(bill_id)
         share_btn = InlineKeyboardButton(
-            text="Share Bill",
+            text="📮 Share Bill",
             switch_inline_query=bill_name
         )
         refresh_btn = InlineKeyboardButton(
-            text="Refresh Bill",
+            text="🔄 Refresh Bill",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_REFRESH_BILL,
@@ -821,7 +846,7 @@ class SendDebtsBillAdmin(Action):
             )
         )
         confirm_btn = InlineKeyboardButton(
-            text="Confirm Payments",
+            text="🤑 Confirm Payments",
             callback_data=utils.get_action_callback_data(
                 MODULE_ACTION_TYPE,
                 ACTION_GET_CONFIRM_PAYMENTS_KB,

--- a/database.py
+++ b/database.py
@@ -567,6 +567,26 @@ class Transaction:
             self.is_error = True
             raise e
 
+    def has_bill_share(self, bill_id, item_id, user_id):
+        try:
+            self.cursor.execute("""\
+                SELECT id from bill_shares
+                    WHERE bill_id =  %s
+                        AND item_id = %s
+                        AND user_id = %s
+                        AND is_deleted = FALSE;
+            """, (bill_id, item_id, user_id)
+            )
+
+            rows = self.cursor.fetchall()
+            if len(rows) < 1:
+                return False
+            else:
+                return True
+        except Exception as e:
+            self.is_error = True
+            raise e
+
     def add_debtors(self, bill_id, creditor_id, debtors):
         try:
             if len(debtors) < 1:


### PR DESCRIPTION
Feature request from #4.

Notably
- All keyboard button text has emoticons except `inspect` set of functions as it is still in development
- "☝️ Share {item_name}"
- "👋 Unshare {item_name}"
- "🙌 Share all items"
- New text "🙅 Unshare all items" when user is already sharing all items