### PR TITLE
Fix setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -64,7 +64,7 @@ docker cp $DIR/../migrations $CONTAINER_NAME:/.
 
 for filepath in $DIR/../migrations/*.sql; do
   filename=$(basename $filepath)
-  PGPASSWORD=$POSTGRES_PASSWORD docker exec $CONTAINER_ID psql -h localhost --username=$POSTGRES_USER --dbname=whopay -a -f /migrations/$filename > /dev/null 2>&1
+  PGPASSWORD=$DB_PASS docker exec $CONTAINER_ID psql -h localhost --username=$DB_USER --dbname=whopay -a -f /migrations/$filename > /dev/null 2>&1
 done
 
 echo "Done"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,7 +59,7 @@ done
 
 echo "Seeding db..."
 
-docker exec $CONTAINER_ID mkdir /migrations
+docker exec $CONTAINER_ID mkdir -p /migrations
 docker cp $DIR/../migrations $CONTAINER_NAME:/.
 
 for filepath in $DIR/../migrations/*.sql; do


### PR DESCRIPTION
Missed out the fix of DB credentials for migrations.

Also added a `-p` option to the `mkdir` command for docker. This currently fails if the docker already has the `/migrations` folder