### PR TITLE
Fix unshared items breaking search

### DIFF
--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -5,4 +5,4 @@ set -e
 CONTAINER_ID=$(docker-compose ps -q web)
 CONTAINER_NAME=$(docker ps --format "{{.Names}}" -af "id=$CONTAINER_ID")
 
-docker exec -it $CONTAINER_ID tail -f /logs/whopay.txt
+docker logs -f $CONTAINER_ID

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,4 @@ if __name__ == '__main__':
         'level': logging.INFO
     }
 
-    if not settings.IS_PROD:
-        logging_kwargs['filename'] = '/logs/whopay.txt'
-
     logging.basicConfig(**logging_kwargs)


### PR DESCRIPTION
Search for bills assume that all items have sharers. Previous implementation allowed splitting of bills when the bill had unshared items (bug). This broke search.

Fix prevents user from calculating split when there are unshared items. (All items should be shared since someone paid for it).